### PR TITLE
Create initial menu for tower defense game

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/build/
+/.idea/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.16)
+project(TowerDefense)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
+
+add_executable(tower_defense
+    src/main.cpp
+)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,67 @@
+#include <iostream>
+#include <array>
+#include <string_view>
+#include <limits>
+
+namespace {
+void printHeader() {
+    std::cout << "============================\n"
+              << "    Tower Defense Menu\n"
+              << "============================\n";
+}
+
+void printMenuOptions() {
+    constexpr std::array<std::string_view, 3> options{"Play", "Settings", "Quit"};
+
+    for (std::size_t index = 0; index < options.size(); ++index) {
+        std::cout << index + 1 << ") " << options[index] << '\n';
+    }
+    std::cout << "\nSelect an option: ";
+}
+
+bool handleChoice(int choice) {
+    switch (choice) {
+        case 1:
+            std::cout << "Starting the game... (placeholder)\n";
+            break;
+        case 2:
+            std::cout << "Opening settings... (placeholder)\n";
+            break;
+        case 3:
+            std::cout << "Exiting. Goodbye!\n";
+            return false;
+        default:
+            std::cout << "Invalid option. Please choose 1, 2, or 3.\n";
+            break;
+    }
+    return true;
+}
+}
+
+int main() {
+    bool running = true;
+
+    while (running) {
+        printHeader();
+        printMenuOptions();
+
+        int choice = 0;
+        if (!(std::cin >> choice)) {
+            std::cout << "Input error. Please enter numbers only.\n";
+            std::cin.clear();
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            continue;
+        }
+
+        running = handleChoice(choice);
+
+        if (running) {
+            std::cout << "\nPress Enter to return to the menu...";
+            std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+            std::cin.get();
+        }
+        std::cout << '\n';
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- set up a CMake-based C++ project structure for the tower defense game
- implement a console menu loop with Play, Settings, and Quit options and basic handling
- add ignore rules for generated build artifacts and IDE metadata

## Testing
- cmake -S . -B build
- cmake --build build


------
https://chatgpt.com/codex/tasks/task_e_68cf398cdf8083268288e653c68ec037